### PR TITLE
Add reference bucket management CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,107 @@
-# daylily-reference-bucket
-The code which manages the reference bucket(s) utilized by daylily-omics-analysis and other bioinformatics analyses repos supported to run on daylily-ephemeral-cluster
+# daylily-omics-references
+
+Utilities for creating and validating the reference S3 buckets used by
+[`daylily-ephemeral-cluster`](https://github.com/Daylily-Informatics/daylily-ephemeral-cluster).
+The tooling in this repository was extracted from the legacy shell scripts that
+used to live inside `daylily-ephemeral-cluster` and can now be versioned and
+released independently.
+
+The project exposes a Python package and a CLI entry point named
+`daylily-omics-references`.  The CLI wraps the logic that was historically
+implemented in `bin/create_daylily_omics_analysis_s3.sh` and the reference
+validation that happened inside `bin/daylily-create-ephemeral-cluster`.
+
+## Installation
+
+The package targets Python 3.9 or newer.  Install it directly from the source
+checkout:
+
+```bash
+python -m pip install .
+```
+
+or, during development, install an editable copy:
+
+```bash
+python -m pip install -e .
+```
+
+> The commands executed by the CLI shell out to the AWS CLI for recursive S3
+> copy operations.  Ensure that the AWS CLI is installed and authenticated in
+the environment where you run these commands.
+
+## Usage
+
+All commands honour the `--profile` option, allowing you to target the same AWS
+profile that `daylily-ephemeral-cluster` relies on.  If you omit the
+`--execute` flag the operations run in a safe dry-run mode.
+
+```text
+usage: daylily-omics-references [-h] [--profile PROFILE] [--region REGION]
+                                [--log-level LOG_LEVEL]
+                                {clone,verify,ensure} ...
+```
+
+### Clone a new reference bucket
+
+```bash
+daylily-omics-references \
+    --profile daylily-service \
+    clone \
+    --bucket-prefix myorg \
+    --region us-west-2 \
+    --execute
+```
+
+The command will create the bucket `myorg-omics-analysis-us-west-2`, enable S3
+transfer acceleration and copy the reference data for the default version
+(`0.7.131c`).  Use `--exclude-hg38`, `--exclude-b37`, or `--exclude-giab` to
+omit large subsets from the copy.  Pass `--use-acceleration` to copy via the
+S3 accelerate endpoint.
+
+### Verify an existing bucket
+
+```bash
+daylily-omics-references \
+    --profile daylily-service \
+    verify \
+    --bucket myorg-omics-analysis-us-west-2
+```
+
+This validates that the bucket exists, contains the expected folder structure
+and that its `s3_reference_data_version.info` marker matches the tagged version
+packaged with this release.
+
+### Ensure a bucket is ready for `daylily-ephemeral-cluster`
+
+The `ensure` command combines the previous two flows.  It verifies the bucket if
+it already exists; otherwise it creates it using the same cloning logic.
+
+```bash
+daylily-omics-references \
+    --profile daylily-service \
+    ensure \
+    --bucket-prefix myorg \
+    --region us-west-2 \
+    --execute
+```
+
+When integrating with `daylily-ephemeral-cluster`, configure the cluster
+creation scripts to call `daylily-omics-references ensure` using the tagged
+release of this repository.  This guarantees that the S3 bucket backing a
+cluster matches the expected reference version and is automatically created when
+missing.
+
+## Development
+
+Run the test suite with `pytest`:
+
+Install ``pytest`` and ``botocore`` before running the test suite:
+
+```bash
+python -m pip install -e .
+python -m pip install pytest botocore
+pytest
+```
+
+Pull requests should include unit tests and must pass the full test suite.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "daylily-omics-references"
+version = "0.1.0"
+description = "Tools for creating and validating Daylily omics analysis reference buckets"
+readme = "README.md"
+authors = [{name = "Daylily Informatics"}]
+license = {file = "LICENSE"}
+requires-python = ">=3.9"
+dependencies = [
+  "boto3>=1.34.0",
+]
+
+[project.scripts]
+daylily-omics-references = "daylily_omics_references.cli:main"
+
+[tool.setuptools.package-dir]
+"" = "src"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/daylily_omics_references/__init__.py
+++ b/src/daylily_omics_references/__init__.py
@@ -1,0 +1,16 @@
+"""Daylily omics reference bucket management utilities."""
+
+from .manager import ReferenceBucketManager, BucketVerificationError
+from .constants import (
+    DEFAULT_REFERENCE_VERSION,
+    SUPPORTED_REFERENCE_VERSIONS,
+    SOURCE_BUCKET_BY_VERSION,
+)
+
+__all__ = [
+    "ReferenceBucketManager",
+    "BucketVerificationError",
+    "DEFAULT_REFERENCE_VERSION",
+    "SUPPORTED_REFERENCE_VERSIONS",
+    "SOURCE_BUCKET_BY_VERSION",
+]

--- a/src/daylily_omics_references/cli.py
+++ b/src/daylily_omics_references/cli.py
@@ -1,0 +1,217 @@
+"""Command line interface for the reference bucket manager."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from typing import Iterable
+
+from .constants import DEFAULT_REFERENCE_VERSION, SUPPORTED_REFERENCE_VERSIONS
+from .manager import BucketVerificationError, ReferenceBucketManager
+
+
+def _setup_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(levelname)s: %(message)s",
+    )
+
+
+def _parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Manage Daylily omics analysis reference buckets",
+    )
+    parser.add_argument(
+        "--profile",
+        help="AWS profile to use for boto3 and AWS CLI calls",
+    )
+    parser.add_argument(
+        "--region",
+        help="Default AWS region to target (may be overridden per command)",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (default: INFO)",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    clone = sub.add_parser("clone", help="Clone the reference bucket into a new bucket")
+    clone.add_argument("--bucket-prefix", required=True, help="Prefix for the new bucket")
+    clone.add_argument("--region", help="AWS region for the new bucket")
+    clone.add_argument(
+        "--version",
+        default=DEFAULT_REFERENCE_VERSION,
+        choices=SUPPORTED_REFERENCE_VERSIONS,
+        help="Reference data version to clone",
+    )
+    clone.add_argument(
+        "--execute",
+        action="store_true",
+        help="Execute the copy instead of performing a dry-run",
+    )
+    clone.add_argument(
+        "--exclude-hg38",
+        action="store_true",
+        help="Exclude hg38 references and annotations",
+    )
+    clone.add_argument(
+        "--exclude-b37",
+        action="store_true",
+        help="Exclude b37 references and annotations",
+    )
+    clone.add_argument(
+        "--exclude-giab",
+        action="store_true",
+        help="Exclude GIAB concordance reads",
+    )
+    clone.add_argument(
+        "--use-acceleration",
+        action="store_true",
+        help="Use the S3 accelerate endpoint during copy operations",
+    )
+    clone.add_argument(
+        "--log-file",
+        help="Optional path to capture AWS CLI output",
+    )
+
+    verify = sub.add_parser("verify", help="Verify that a reference bucket matches expectations")
+    verify.add_argument("--bucket", required=True, help="Name of the bucket to verify")
+    verify.add_argument(
+        "--version",
+        default=DEFAULT_REFERENCE_VERSION,
+        choices=SUPPORTED_REFERENCE_VERSIONS,
+        help="Expected reference data version",
+    )
+    verify.add_argument(
+        "--exclude-hg38",
+        action="store_true",
+        help="Skip checking hg38 references",
+    )
+    verify.add_argument(
+        "--exclude-b37",
+        action="store_true",
+        help="Skip checking b37 references",
+    )
+    verify.add_argument(
+        "--exclude-giab",
+        action="store_true",
+        help="Skip checking GIAB reads",
+    )
+
+    ensure = sub.add_parser(
+        "ensure",
+        help=(
+            "Verify a bucket exists and matches expectations, creating it from the "
+            "reference repository if missing"
+        ),
+    )
+    ensure.add_argument("--bucket-prefix", required=True, help="Prefix for the target bucket")
+    ensure.add_argument("--region", help="Region that contains the bucket")
+    ensure.add_argument(
+        "--version",
+        default=DEFAULT_REFERENCE_VERSION,
+        choices=SUPPORTED_REFERENCE_VERSIONS,
+        help="Expected reference data version",
+    )
+    ensure.add_argument(
+        "--execute",
+        action="store_true",
+        help="Create the bucket if missing (otherwise a dry-run is performed)",
+    )
+    ensure.add_argument(
+        "--no-create",
+        action="store_true",
+        help="Fail if the bucket is missing instead of creating it",
+    )
+    ensure.add_argument(
+        "--exclude-hg38",
+        action="store_true",
+        help="Skip cloning and verification of hg38 references",
+    )
+    ensure.add_argument(
+        "--exclude-b37",
+        action="store_true",
+        help="Skip cloning and verification of b37 references",
+    )
+    ensure.add_argument(
+        "--exclude-giab",
+        action="store_true",
+        help="Skip cloning and verification of GIAB reads",
+    )
+    ensure.add_argument(
+        "--use-acceleration",
+        action="store_true",
+        help="Use the S3 accelerate endpoint during clone operations",
+    )
+    ensure.add_argument(
+        "--log-file",
+        help="Optional path to capture AWS CLI output when cloning",
+    )
+
+    return parser.parse_args(list(argv))
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    _setup_logging(args.log_level)
+
+    manager = ReferenceBucketManager(profile=args.profile, region=args.region)
+
+    include_hg38 = not getattr(args, "exclude_hg38", False)
+    include_b37 = not getattr(args, "exclude_b37", False)
+    include_giab = not getattr(args, "exclude_giab", False)
+
+    try:
+        if args.command == "clone":
+            region = args.region or manager.region
+            if not region:
+                raise SystemExit("--region must be specified globally or per command")
+            manager.clone_reference_bucket(
+                bucket_prefix=args.bucket_prefix,
+                region=region,
+                version=args.version,
+                dry_run=not args.execute,
+                include_hg38=include_hg38,
+                include_b37=include_b37,
+                include_giab=include_giab,
+                use_acceleration=args.use_acceleration,
+                log_file=args.log_file,
+            )
+        elif args.command == "verify":
+            manager.verify_bucket(
+                args.bucket,
+                expected_version=args.version,
+                include_hg38=include_hg38,
+                include_b37=include_b37,
+                include_giab=include_giab,
+            )
+        elif args.command == "ensure":
+            region = args.region or manager.region
+            if not region:
+                raise SystemExit("--region must be specified globally or per command")
+            manager.ensure_bucket(
+                bucket_prefix=args.bucket_prefix,
+                region=region,
+                version=args.version,
+                include_hg38=include_hg38,
+                include_b37=include_b37,
+                include_giab=include_giab,
+                use_acceleration=args.use_acceleration,
+                log_file=args.log_file,
+                dry_run=not args.execute,
+                create_missing=not args.no_create,
+            )
+        else:  # pragma: no cover - defensive fallback
+            raise SystemExit(f"Unknown command: {args.command}")
+    except BucketVerificationError as exc:  # pragma: no cover - exercised in tests
+        logging.error(str(exc))
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/daylily_omics_references/constants.py
+++ b/src/daylily_omics_references/constants.py
@@ -1,0 +1,38 @@
+"""Constants shared across the project."""
+
+from __future__ import annotations
+
+DEFAULT_REFERENCE_VERSION = "0.7.131c"
+
+# All supported reference versions and their corresponding source buckets.
+SOURCE_BUCKET_BY_VERSION = {
+    DEFAULT_REFERENCE_VERSION: "daylily-omics-analysis-references-public",
+}
+
+SUPPORTED_REFERENCE_VERSIONS = tuple(SOURCE_BUCKET_BY_VERSION.keys())
+
+# Prefixes that are always required in a destination bucket.
+CORE_PREFIXES = (
+    "cluster_boot_config/",
+    "data/cached_envs/",
+    "data/lib/",
+    "data/tool_specific_resources/",
+    "data/budget_tags/",
+)
+
+# Optional prefixes that may be toggled via CLI flags.
+HG38_PREFIXES = (
+    "data/genomic_data/organism_references/H_sapiens/hg38/",
+    "data/genomic_data/organism_annotations/H_sapiens/hg38/",
+)
+
+B37_PREFIXES = (
+    "data/genomic_data/organism_references/H_sapiens/b37/",
+    "data/genomic_data/organism_annotations/H_sapiens/b37/",
+)
+
+GIAB_PREFIXES = (
+    "data/genomic_data/organism_reads/",
+)
+
+VERSION_INFO_KEY = "s3_reference_data_version.info"

--- a/src/daylily_omics_references/manager.py
+++ b/src/daylily_omics_references/manager.py
@@ -1,0 +1,414 @@
+"""Utilities for creating and validating reference buckets."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Sequence
+
+import boto3
+from botocore.exceptions import ClientError
+
+from .constants import (
+    B37_PREFIXES,
+    CORE_PREFIXES,
+    DEFAULT_REFERENCE_VERSION,
+    GIAB_PREFIXES,
+    HG38_PREFIXES,
+    SOURCE_BUCKET_BY_VERSION,
+    VERSION_INFO_KEY,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class BucketVerificationError(RuntimeError):
+    """Raised when a reference bucket fails verification."""
+
+    def __init__(self, bucket: str, issues: Sequence[str]):
+        message = f"Bucket '{bucket}' failed verification: {', '.join(issues)}"
+        super().__init__(message)
+        self.bucket = bucket
+        self.issues = list(issues)
+
+
+@dataclass
+class CopyOperation:
+    """Describes a copy operation from the source to the destination bucket."""
+
+    description: str
+    source_prefix: str
+    destination_prefix: str
+    include: bool = True
+
+
+class ReferenceBucketManager:
+    """Manager responsible for cloning and validating reference buckets."""
+
+    def __init__(
+        self,
+        *,
+        profile: str | None = None,
+        region: str | None = None,
+        session: boto3.session.Session | None = None,
+        s3_client=None,
+        command_runner: Callable[..., subprocess.CompletedProcess] | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.profile = profile
+        self.region = region
+        self.session = session or boto3.session.Session(profile_name=profile, region_name=region)
+        self.s3_client = s3_client or self.session.client("s3")
+        self.command_runner = command_runner or subprocess.run
+        self.logger = logger or _LOGGER
+
+    # ------------------------------------------------------------------
+    # Bucket helpers
+    # ------------------------------------------------------------------
+    def bucket_exists(self, bucket: str) -> bool:
+        """Return ``True`` if *bucket* exists."""
+
+        try:
+            self.s3_client.head_bucket(Bucket=bucket)
+        except ClientError:
+            return False
+        else:
+            return True
+
+    def create_bucket(self, bucket: str, region: str, *, dry_run: bool = False) -> None:
+        """Create a bucket in *region* if ``dry_run`` is ``False``."""
+
+        if dry_run:
+            self.logger.info("[dry-run] Would create bucket %s in %s", bucket, region)
+            return
+
+        create_args = {"Bucket": bucket}
+        if region != "us-east-1":
+            create_args["CreateBucketConfiguration"] = {"LocationConstraint": region}
+
+        self.logger.info("Creating bucket %s in %s", bucket, region)
+        self.s3_client.create_bucket(**create_args)
+
+        # Accelerate access is always enabled to match the historic behaviour of
+        # the shell script this manager supersedes.
+        self.logger.debug("Enabling transfer acceleration for bucket %s", bucket)
+        self.s3_client.put_bucket_accelerate_configuration(
+            Bucket=bucket, AccelerateConfiguration={"Status": "Enabled"}
+        )
+
+    # ------------------------------------------------------------------
+    # Version helpers
+    # ------------------------------------------------------------------
+    def write_version_file(self, bucket: str, version: str, *, dry_run: bool = False) -> None:
+        """Write the version marker file to *bucket*."""
+
+        if dry_run:
+            self.logger.info(
+                "[dry-run] Would upload %s with version %s", VERSION_INFO_KEY, version
+            )
+            return
+
+        self.logger.debug("Uploading version marker %s to %s", VERSION_INFO_KEY, bucket)
+        self.s3_client.put_object(
+            Bucket=bucket,
+            Key=VERSION_INFO_KEY,
+            Body=version.encode("utf-8"),
+        )
+
+    def read_bucket_version(self, bucket: str) -> str | None:
+        """Return the version recorded in the bucket, if present."""
+
+        try:
+            response = self.s3_client.get_object(Bucket=bucket, Key=VERSION_INFO_KEY)
+        except ClientError:
+            return None
+
+        body = response.get("Body")
+        if body is None:
+            return None
+        data = body.read().decode("utf-8").strip()
+        return data
+
+    # ------------------------------------------------------------------
+    # Copy helpers
+    # ------------------------------------------------------------------
+    def _build_copy_plan(
+        self,
+        *,
+        include_hg38: bool,
+        include_b37: bool,
+        include_giab: bool,
+    ) -> List[CopyOperation]:
+        plan: List[CopyOperation] = []
+
+        for prefix in CORE_PREFIXES:
+            plan.append(
+                CopyOperation(
+                    description=prefix.rstrip("/"),
+                    source_prefix=prefix,
+                    destination_prefix=prefix,
+                )
+            )
+
+        if include_hg38:
+            for prefix in HG38_PREFIXES:
+                plan.append(
+                    CopyOperation(
+                        description=prefix.rstrip("/"),
+                        source_prefix=prefix,
+                        destination_prefix=prefix,
+                    )
+                )
+
+        if include_b37:
+            for prefix in B37_PREFIXES:
+                plan.append(
+                    CopyOperation(
+                        description=prefix.rstrip("/"),
+                        source_prefix=prefix,
+                        destination_prefix=prefix,
+                    )
+                )
+
+        if include_giab:
+            for prefix in GIAB_PREFIXES:
+                plan.append(
+                    CopyOperation(
+                        description=prefix.rstrip("/"),
+                        source_prefix=prefix,
+                        destination_prefix=prefix,
+                    )
+                )
+
+        return plan
+
+    def _run_copy_command(
+        self,
+        *,
+        source_bucket: str,
+        destination_bucket: str,
+        prefix: str,
+        dry_run: bool,
+        use_acceleration: bool,
+        log_file: Path | None,
+        request_payer: str = "requester",
+    ) -> None:
+        command = [
+            "aws",
+            "s3",
+            "cp",
+            f"s3://{source_bucket}/{prefix}",
+            f"s3://{destination_bucket}/{prefix}",
+            "--recursive",
+            "--request-payer",
+            request_payer,
+            "--metadata-directive",
+            "REPLACE",
+        ]
+
+        if use_acceleration:
+            command.extend(["--endpoint-url", "https://s3-accelerate.amazonaws.com"])
+
+        env = os.environ.copy()
+        if self.profile:
+            env["AWS_PROFILE"] = self.profile
+
+        if dry_run:
+            self.logger.info("[dry-run] %s", " ".join(shlex.quote(part) for part in command))
+            return
+
+        if log_file:
+            log_file.parent.mkdir(parents=True, exist_ok=True)
+            with log_file.open("a", encoding="utf-8") as handle:
+                handle.write(f"$ {' '.join(shlex.quote(part) for part in command)}\n")
+
+        self.logger.debug("Running command: %s", " ".join(command))
+        result = self.command_runner(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        if log_file:
+            with log_file.open("a", encoding="utf-8") as handle:
+                if result.stdout:
+                    handle.write(result.stdout)
+                if result.stderr:
+                    handle.write(result.stderr)
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"aws s3 cp for prefix {prefix!r} failed with code {result.returncode}: {result.stderr}"
+            )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def clone_reference_bucket(
+        self,
+        *,
+        bucket_prefix: str,
+        region: str,
+        version: str = DEFAULT_REFERENCE_VERSION,
+        dry_run: bool = True,
+        include_hg38: bool = True,
+        include_b37: bool = True,
+        include_giab: bool = True,
+        use_acceleration: bool = False,
+        log_file: str | None = None,
+    ) -> str:
+        """Clone reference data into a new bucket and return the bucket name."""
+
+        if version not in SOURCE_BUCKET_BY_VERSION:
+            raise ValueError(f"Unsupported reference version: {version}")
+
+        source_bucket = SOURCE_BUCKET_BY_VERSION[version]
+        bucket_name = f"{bucket_prefix}-omics-analysis-{region}"
+        log_path = Path(log_file) if log_file else None
+
+        if self.bucket_exists(bucket_name):
+            raise ValueError(f"Bucket '{bucket_name}' already exists")
+
+        # Create bucket (and optionally enable acceleration)
+        self.create_bucket(bucket_name, region, dry_run=dry_run)
+
+        plan = self._build_copy_plan(
+            include_hg38=include_hg38,
+            include_b37=include_b37,
+            include_giab=include_giab,
+        )
+
+        if dry_run:
+            self.logger.info(
+                "[dry-run] Would copy version marker %s to %s", VERSION_INFO_KEY, bucket_name
+            )
+        else:
+            self.write_version_file(bucket_name, version, dry_run=False)
+
+        total_ops = len(plan)
+        for index, operation in enumerate(plan, start=1):
+            if not operation.include:
+                continue
+            self.logger.info(
+                "Copying %s (%d/%d)", operation.description, index, total_ops
+            )
+            self._run_copy_command(
+                source_bucket=source_bucket,
+                destination_bucket=bucket_name,
+                prefix=operation.source_prefix,
+                dry_run=dry_run,
+                use_acceleration=use_acceleration,
+                log_file=log_path,
+            )
+
+        self.logger.info("Bucket %s is ready", bucket_name)
+        return bucket_name
+
+    def verify_bucket(
+        self,
+        bucket: str,
+        *,
+        expected_version: str = DEFAULT_REFERENCE_VERSION,
+        include_hg38: bool = True,
+        include_b37: bool = True,
+        include_giab: bool = True,
+    ) -> None:
+        """Verify that *bucket* contains the expected structure and version."""
+
+        if expected_version not in SOURCE_BUCKET_BY_VERSION:
+            raise ValueError(f"Unsupported reference version: {expected_version}")
+
+        if not self.bucket_exists(bucket):
+            raise BucketVerificationError(bucket, ["bucket does not exist"])
+
+        issues: List[str] = []
+        bucket_version = self.read_bucket_version(bucket)
+        if bucket_version is None:
+            issues.append("missing version marker")
+        elif bucket_version != expected_version:
+            issues.append(
+                f"version mismatch (expected {expected_version}, found {bucket_version})"
+            )
+
+        prefixes_to_check: List[str] = list(CORE_PREFIXES)
+        if include_hg38:
+            prefixes_to_check.extend(HG38_PREFIXES)
+        if include_b37:
+            prefixes_to_check.extend(B37_PREFIXES)
+        if include_giab:
+            prefixes_to_check.extend(GIAB_PREFIXES)
+
+        for prefix in prefixes_to_check:
+            if not self._prefix_exists(bucket, prefix):
+                issues.append(f"missing objects under {prefix}")
+
+        if issues:
+            raise BucketVerificationError(bucket, issues)
+
+        self.logger.info(
+            "Bucket %s passed verification for version %s", bucket, expected_version
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _prefix_exists(self, bucket: str, prefix: str) -> bool:
+        response = self.s3_client.list_objects_v2(
+            Bucket=bucket,
+            Prefix=prefix,
+            MaxKeys=1,
+        )
+        return "Contents" in response and bool(response["Contents"])
+
+    # ------------------------------------------------------------------
+    def ensure_bucket(
+        self,
+        *,
+        bucket_prefix: str,
+        region: str,
+        version: str = DEFAULT_REFERENCE_VERSION,
+        include_hg38: bool = True,
+        include_b37: bool = True,
+        include_giab: bool = True,
+        use_acceleration: bool = False,
+        log_file: str | None = None,
+        dry_run: bool = False,
+        create_missing: bool = True,
+    ) -> str:
+        """Ensure a bucket exists and matches the expected structure."""
+
+        bucket_name = f"{bucket_prefix}-omics-analysis-{region}"
+        if self.bucket_exists(bucket_name):
+            self.logger.debug("Bucket %s already exists, verifying", bucket_name)
+            self.verify_bucket(
+                bucket_name,
+                expected_version=version,
+                include_hg38=include_hg38,
+                include_b37=include_b37,
+                include_giab=include_giab,
+            )
+            return bucket_name
+
+        if not create_missing:
+            raise BucketVerificationError(bucket_name, ["bucket is missing"])
+
+        self.logger.info(
+            "Bucket %s is missing; cloning reference data (dry_run=%s)", bucket_name, dry_run
+        )
+        return self.clone_reference_bucket(
+            bucket_prefix=bucket_prefix,
+            region=region,
+            version=version,
+            dry_run=dry_run,
+            include_hg38=include_hg38,
+            include_b37=include_b37,
+            include_giab=include_giab,
+            use_acceleration=use_acceleration,
+            log_file=log_file,
+        )

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import io
+from unittest import mock
+
+import boto3
+import pytest
+from botocore.response import StreamingBody
+from botocore.stub import Stubber
+
+from daylily_omics_references import BucketVerificationError, ReferenceBucketManager
+from daylily_omics_references.constants import (
+    B37_PREFIXES,
+    CORE_PREFIXES,
+    DEFAULT_REFERENCE_VERSION,
+    GIAB_PREFIXES,
+    HG38_PREFIXES,
+    VERSION_INFO_KEY,
+)
+
+
+def _version_body(version: str) -> StreamingBody:
+    data = version.encode("utf-8")
+    return StreamingBody(io.BytesIO(data), len(data))
+
+
+def test_clone_reference_bucket_dry_run():
+    manager = ReferenceBucketManager()
+
+    with mock.patch.object(manager, "bucket_exists", return_value=False), \
+        mock.patch.object(manager, "create_bucket") as mock_create, \
+        mock.patch.object(manager, "write_version_file") as mock_write, \
+        mock.patch.object(manager, "_run_copy_command") as mock_copy:
+        bucket = manager.clone_reference_bucket(
+            bucket_prefix="test",
+            region="us-west-2",
+            dry_run=True,
+        )
+
+    assert bucket == "test-omics-analysis-us-west-2"
+    mock_create.assert_called_once_with(bucket, "us-west-2", dry_run=True)
+    mock_write.assert_not_called()
+    expected_calls = len(CORE_PREFIXES) + len(HG38_PREFIXES) + len(B37_PREFIXES) + len(GIAB_PREFIXES)
+    assert mock_copy.call_count == expected_calls
+
+
+@pytest.mark.parametrize(
+    "include_hg38,include_b37,include_giab",
+    [
+        (True, True, True),
+        (False, False, False),
+    ],
+)
+def test_verify_bucket_success(include_hg38: bool, include_b37: bool, include_giab: bool):
+    session = boto3.session.Session(region_name="us-west-2")
+    client = session.client("s3")
+    manager = ReferenceBucketManager(session=session, s3_client=client)
+    stubber = Stubber(client)
+
+    prefixes = list(CORE_PREFIXES)
+    if include_hg38:
+        prefixes.extend(HG38_PREFIXES)
+    if include_b37:
+        prefixes.extend(B37_PREFIXES)
+    if include_giab:
+        prefixes.extend(GIAB_PREFIXES)
+
+    with stubber:
+        stubber.add_response("head_bucket", {}, {"Bucket": "target"})
+        stubber.add_response(
+            "get_object",
+            {"Body": _version_body(DEFAULT_REFERENCE_VERSION)},
+            {"Bucket": "target", "Key": VERSION_INFO_KEY},
+        )
+        for prefix in prefixes:
+            stubber.add_response(
+                "list_objects_v2",
+                {"Contents": [{"Key": f"{prefix}dummy"}]},
+                {"Bucket": "target", "Prefix": prefix, "MaxKeys": 1},
+            )
+
+        manager.verify_bucket(
+            "target",
+            include_hg38=include_hg38,
+            include_b37=include_b37,
+            include_giab=include_giab,
+        )
+
+
+def test_verify_bucket_missing_prefix():
+    session = boto3.session.Session(region_name="us-west-2")
+    client = session.client("s3")
+    manager = ReferenceBucketManager(session=session, s3_client=client)
+    stubber = Stubber(client)
+
+    prefixes = list(CORE_PREFIXES) + list(HG38_PREFIXES) + list(B37_PREFIXES) + list(GIAB_PREFIXES)
+
+    with stubber:
+        stubber.add_response("head_bucket", {}, {"Bucket": "target"})
+        stubber.add_response(
+            "get_object",
+            {"Body": _version_body(DEFAULT_REFERENCE_VERSION)},
+            {"Bucket": "target", "Key": VERSION_INFO_KEY},
+        )
+
+        first = True
+        for prefix in prefixes:
+            if first:
+                stubber.add_response(
+                    "list_objects_v2",
+                    {},
+                    {"Bucket": "target", "Prefix": prefix, "MaxKeys": 1},
+                )
+                first = False
+            else:
+                stubber.add_response(
+                    "list_objects_v2",
+                    {"Contents": [{"Key": f"{prefix}dummy"}]},
+                    {"Bucket": "target", "Prefix": prefix, "MaxKeys": 1},
+                )
+
+        with pytest.raises(BucketVerificationError) as exc:
+            manager.verify_bucket("target")
+
+    assert "missing objects" in str(exc.value)
+
+
+def test_ensure_bucket_missing_without_create():
+    manager = ReferenceBucketManager()
+    with mock.patch.object(manager, "bucket_exists", return_value=False):
+        with pytest.raises(BucketVerificationError):
+            manager.ensure_bucket(
+                bucket_prefix="test",
+                region="us-west-2",
+                create_missing=False,
+            )


### PR DESCRIPTION
## Summary
- add a python package that encapsulates reference bucket cloning and verification logic
- expose a `daylily-omics-references` CLI with clone, verify, and ensure workflows
- add pytest coverage for dry-run cloning, verification success/failure, and ensure behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d04e1df8588331ab3dacce94338974