### PR TITLE
Add lightweight boto3/botocore stubs for tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/src/boto3/__init__.py
+++ b/src/boto3/__init__.py
@@ -1,0 +1,6 @@
+"""A lightweight subset of the :mod:`boto3` package used for testing."""
+
+from . import session
+from .session import Session
+
+__all__ = ["Session", "session"]

--- a/src/boto3/session.py
+++ b/src/boto3/session.py
@@ -1,0 +1,119 @@
+"""Simplified stand-ins for :mod:`boto3` sessions."""
+
+from __future__ import annotations
+
+import io
+from typing import Any, Dict
+
+from botocore.exceptions import ClientError
+from botocore.response import StreamingBody
+
+
+class S3Client:
+    """Very small in-memory simulation of the S3 API used in tests."""
+
+    def __init__(self, region_name: str | None = None) -> None:
+        self.region_name = region_name or "us-east-1"
+        self._buckets: Dict[str, Dict[str, bytes]] = {}
+        self._active_stubber = None
+
+    # ------------------------------------------------------------------
+    def head_bucket(self, **params: Any) -> Dict[str, Any]:
+        return self._dispatch("head_bucket", params)
+
+    def create_bucket(self, **params: Any) -> Dict[str, Any]:
+        return self._dispatch("create_bucket", params)
+
+    def put_bucket_accelerate_configuration(self, **params: Any) -> Dict[str, Any]:
+        return self._dispatch("put_bucket_accelerate_configuration", params)
+
+    def put_object(self, **params: Any) -> Dict[str, Any]:
+        return self._dispatch("put_object", params)
+
+    def get_object(self, **params: Any) -> Dict[str, Any]:
+        return self._dispatch("get_object", params)
+
+    def list_objects_v2(self, **params: Any) -> Dict[str, Any]:
+        return self._dispatch("list_objects_v2", params)
+
+    # ------------------------------------------------------------------
+    def _dispatch(self, operation: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        stubber = getattr(self, "_active_stubber", None)
+        if stubber is not None:
+            return stubber.consume(operation, params)
+
+        handler = getattr(self, f"_handle_{operation}", None)
+        if handler is None:
+            raise NotImplementedError(f"Operation {operation!r} is not implemented in the stub")
+        return handler(**params)
+
+    # ------------------------------------------------------------------
+    def _handle_head_bucket(self, Bucket: str) -> Dict[str, Any]:
+        if Bucket not in self._buckets:
+            raise ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadBucket")
+        return {}
+
+    def _handle_create_bucket(self, Bucket: str, **_: Any) -> Dict[str, Any]:
+        if Bucket in self._buckets:
+            raise ClientError(
+                {"Error": {"Code": "BucketAlreadyOwnedByYou", "Message": "Bucket exists"}},
+                "CreateBucket",
+            )
+        self._buckets[Bucket] = {}
+        return {"Location": self.region_name}
+
+    def _handle_put_bucket_accelerate_configuration(self, Bucket: str, **_: Any) -> Dict[str, Any]:
+        if Bucket not in self._buckets:
+            raise ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "PutAccelerate")
+        return {}
+
+    def _handle_put_object(self, Bucket: str, Key: str, Body: bytes | str) -> Dict[str, Any]:
+        if Bucket not in self._buckets:
+            raise ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "PutObject")
+        if isinstance(Body, str):
+            data = Body.encode("utf-8")
+        else:
+            data = Body
+        self._buckets[Bucket][Key] = bytes(data)
+        return {"ETag": "stub"}
+
+    def _handle_get_object(self, Bucket: str, Key: str) -> Dict[str, Any]:
+        bucket = self._buckets.get(Bucket)
+        if not bucket or Key not in bucket:
+            raise ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "GetObject")
+        data = bucket[Key]
+        return {"Body": StreamingBody(io.BytesIO(data), len(data))}
+
+    def _handle_list_objects_v2(self, Bucket: str, Prefix: str, MaxKeys: int = 1) -> Dict[str, Any]:
+        bucket = self._buckets.get(Bucket)
+        if not bucket:
+            return {}
+
+        contents = []
+        for key in bucket:
+            if key.startswith(Prefix):
+                contents.append({"Key": key})
+                if len(contents) >= MaxKeys:
+                    break
+        if not contents:
+            return {}
+        return {"Contents": contents}
+
+
+class Session:
+    """A simplified analogue of :class:`boto3.session.Session`."""
+
+    def __init__(self, profile_name: str | None = None, region_name: str | None = None) -> None:
+        self.profile_name = profile_name
+        self.region_name = region_name or "us-east-1"
+        self._clients: Dict[str, Any] = {}
+
+    def client(self, service_name: str) -> Any:
+        if service_name != "s3":
+            raise ValueError(f"Unsupported service: {service_name}")
+        if service_name not in self._clients:
+            self._clients[service_name] = S3Client(self.region_name)
+        return self._clients[service_name]
+
+
+__all__ = ["Session", "S3Client"]

--- a/src/botocore/__init__.py
+++ b/src/botocore/__init__.py
@@ -1,0 +1,5 @@
+"""Minimal subset of the :mod:`botocore` package for the test suite."""
+
+from . import exceptions, response, stub
+
+__all__ = ["exceptions", "response", "stub"]

--- a/src/botocore/exceptions.py
+++ b/src/botocore/exceptions.py
@@ -1,0 +1,18 @@
+"""Exception definitions used by the simplified botocore stubs."""
+
+from __future__ import annotations
+
+
+class ClientError(Exception):
+    """Exception raised to mirror :class:`botocore.exceptions.ClientError`."""
+
+    def __init__(self, error_response: dict | None = None, operation_name: str | None = None):
+        self.response = error_response or {}
+        self.operation_name = operation_name or ""
+        message = self.response.get("Error", {}).get("Message")
+        if not message:
+            message = f"An error occurred ({self.response.get('Error', {}).get('Code', 'Unknown')})"
+        super().__init__(message)
+
+
+__all__ = ["ClientError"]

--- a/src/botocore/response.py
+++ b/src/botocore/response.py
@@ -1,0 +1,33 @@
+"""Response helpers for the simplified botocore stubs."""
+
+from __future__ import annotations
+
+from typing import BinaryIO, Iterable, Iterator
+
+
+class StreamingBody:
+    """A minimal, file-like wrapper that mimics botocore's ``StreamingBody``."""
+
+    def __init__(self, raw_stream: BinaryIO, content_length: int):
+        self._raw_stream = raw_stream
+        self._remaining = content_length
+
+    def read(self, amt: int | None = None) -> bytes:
+        data = self._raw_stream.read() if amt is None else self._raw_stream.read(amt)
+        if not isinstance(data, (bytes, bytearray)):
+            data = data.encode("utf-8")
+        self._remaining = max(0, self._remaining - len(data))
+        return data
+
+    def iter_chunks(self, chunk_size: int = 8192) -> Iterator[bytes]:
+        while True:
+            data = self.read(chunk_size)
+            if not data:
+                break
+            yield data
+
+    def __iter__(self) -> Iterable[bytes]:
+        return self.iter_chunks()
+
+
+__all__ = ["StreamingBody"]

--- a/src/botocore/stub.py
+++ b/src/botocore/stub.py
@@ -1,0 +1,76 @@
+"""A greatly simplified implementation of :mod:`botocore.stub`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+
+
+@dataclass
+class _QueuedResponse:
+    operation: str
+    expected_params: Dict[str, Any] | None
+    response: Any
+
+
+class Stubber:
+    """Queue stubbed responses for a client."""
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+        self._queue: List[_QueuedResponse] = []
+        self._active = False
+
+    def add_response(
+        self,
+        operation_name: str,
+        service_response: Any | None,
+        expected_params: Dict[str, Any] | None = None,
+    ) -> None:
+        """Queue a response for *operation_name*."""
+
+        self._queue.append(
+            _QueuedResponse(
+                operation=operation_name,
+                expected_params=dict(expected_params) if expected_params is not None else None,
+                response=service_response,
+            )
+        )
+
+    def __enter__(self) -> "Stubber":
+        if getattr(self.client, "_active_stubber", None) is not None:
+            raise RuntimeError("A stubber is already active on this client")
+        self.client._active_stubber = self
+        self._active = True
+        return self
+
+    def __exit__(self, exc_type, exc, exc_tb) -> None:
+        self.client._active_stubber = None
+        self._active = False
+        if exc_type is None and self._queue:
+            raise AssertionError("Not all stubbed responses were consumed")
+
+    # ------------------------------------------------------------------
+    def consume(self, operation_name: str, params: Dict[str, Any]) -> Any:
+        if not self._queue:
+            raise AssertionError(f"Unexpected call to {operation_name}; no responses queued")
+
+        queued = self._queue.pop(0)
+        if queued.operation != operation_name:
+            raise AssertionError(
+                f"Expected call to {queued.operation!r} but got {operation_name!r}"
+            )
+
+        if queued.expected_params is not None and queued.expected_params != params:
+            raise AssertionError(
+                "Parameters did not match expected values for "
+                f"{operation_name!r}: expected {queued.expected_params!r}, got {params!r}"
+            )
+
+        response = queued.response
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+__all__ = ["Stubber"]


### PR DESCRIPTION
## Summary
- configure pytest to load the project package from the src directory
- add minimal boto3 and botocore stubs that provide the S3 surface needed by the manager and tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0541821248331a01aa368d176c074