### PR TITLE
Bump package version to 0.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "daylily-omics-references"
-version = "0.3.1"
+version = "0.3.3"
 description = "Tools for creating and validating Daylily omics analysis reference buckets"
 readme = "README.md"
 authors = [{name = "Daylily Informatics"}]


### PR DESCRIPTION
## Summary
- bump package metadata version from 0.3.1 to 0.3.3 in pyproject.toml

## Verification
- python -m build
- confirmed dist artifacts are generated as 0.3.3
