### PR TITLE
Release reference bucket layout contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,13 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# TLS material
+certs/
+tls/
+ssl/
+*.pem
+*.key
+*.crt
+*.p12
+*.pfx

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ scripts/daylily-omics-references.sh \
   --bucket myorg-omics-analysis-us-west-2
 ```
 
-This validates that the bucket exists, contains the expected folder structure
-and that its `s3_reference_data_version.info` marker matches the default
-version.
+This validates that the bucket exists, contains the expected folder structure,
+has the exact DAY-EC headnode readiness objects that mount under `/fsx/data`,
+and that its `s3_reference_data_version.info` marker matches the default version.
 
 ### Ensure a bucket is ready for `daylily-ephemeral-cluster`
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ scripts/daylily-omics-references.sh \
 ```
 
 This validates that the bucket exists, contains the expected folder structure,
-has the exact DAY-EC headnode readiness objects that mount under `/fsx/data`,
-and that its `s3_reference_data_version.info` marker matches the default version.
+has the exact DAY-EC headnode readiness objects that mount under
+`/fsx/references`, and that its `s3_reference_data_version.info` marker matches
+the default version.
 
 ### Ensure a bucket is ready for `daylily-ephemeral-cluster`
 

--- a/docs/plans/20260526T144550Z_reference_runtime_assets_manifest_scrub_ledger.md
+++ b/docs/plans/20260526T144550Z_reference_runtime_assets_manifest_scrub_ledger.md
@@ -1,0 +1,34 @@
+# References Repo Runtime Assets Manifest And Scrub Ledger
+
+Created: 2026-05-26T14:45:50Z
+
+## Objective
+
+Update `daylily-omics-references` for the new top-level reference layout and
+runtime-assets prefix. The verifier must support private LSMC-style references
+and public Daylily-safe references, and public verification must reject licenses,
+private/commercial assets, and LSMC/RCRF identifiers.
+
+## Gate 0 Inventory
+
+- Repo: `/Users/jmajor/projects/daylily/daylily-omics-references`.
+- Git state: `## codex/headnode-readiness-reference-verifier...origin/codex/headnode-readiness-reference-verifier`.
+- Initial sweep: `rg -n "data/cached_envs|data/tool_specific_resources|data/budget_tags|data/genomic_data|runtime_assets|lsmc|rcrf|lic" src tests` found 33 hits.
+- Current constants still expect `data/cached_envs/`, `data/tool_specific_resources/`, `data/budget_tags/`, and `data/genomic_data/...`.
+- Target layout: `runtime_assets/...` and top-level `genomic_data/...`.
+- Public mirror rule: strip `*.lic`, `*license*`, Sentieon install trees, LSMC/RCRF-named assets, and internal budget tags.
+
+## Ledger
+
+| ID | Area | Requirement | Status | Category | Gate | Owner | Evidence | Root Cause | Terminal Note |
+|---|---|---|---|---|---|---|---|---|---|
+| DOR-RRA-001 | Inventory | Record reference-verifier baseline. | SUCCESS | contract_test | Gate 0 | orchestrator | Gate 0 section. |  | Baseline recorded. |
+| DOR-RRA-002 | Layout constants | Replace old `data/...` runtime/reference expectations with `runtime_assets/...` and top-level `genomic_data/...`. | SUCCESS | feature_implementation | Gate 1 | Agent E | `src/daylily_omics_references/constants.py` now requires `runtime_assets/{cluster_boot_config,cached_envs,tool_specific_resources,budget_tags}/`, DAY-EC object keys under `runtime_assets/...`, and top-level `genomic_data/...` prefixes. |  | Verifier contract matches one-DRA references layout. |
+| DOR-RRA-003 | Public scrub | Add public-safe validation rejecting LSMC/RCRF/license/private/commercial runtime assets. | SUCCESS | feature_implementation | Gate 1 | Agent E | `verify --public-safe` calls `verify_bucket(..., public_safe=True)`; manager scans `runtime_assets/` keys and rejects `.lic`, `license`, `sentieon-genomics`, `lsmc`, `rcrf`, `budget_tags/`, private, and commercial key names. |  | Public Daylily-safe references can be validated separately from private LSMC references. |
+| DOR-RRA-004 | Tests | Add tests for private LSMC-style references and public Daylily-safe references. | SUCCESS | contract_test | Gate 2 | Agent E | `python -m pytest -q` returned `21 passed`; tests cover private runtime assets allowed without `public_safe`, public-safe rejection, and public helper acceptance. |  | References repo local validation is green. |
+| DOR-RRA-005 | Daylily mirror validation | After LSMC validation passes, verify `daylily-dayoa-references-usw2/runtime_assets/` contains only public-safe assets. | OPEN | contract_test | Gate 7 | Agent H |  |  |  |
+
+## Acceptance Notes
+
+- Do not publish license files, Sentieon install trees, or LSMC/RCRF/internal budget material into public Daylily references.
+- Do not delete standalone Daylily buckets without later exact destructive approval.

--- a/docs/plans/20260526T185422Z_reference_layout_release_ledger.md
+++ b/docs/plans/20260526T185422Z_reference_layout_release_ledger.md
@@ -1,0 +1,30 @@
+# Daylily Omics References Layout Release Ledger
+
+Controlling plan: DayRef side of the 15-agent bucket contract release and `bucketsamok` validation.
+Ledger path: `docs/plans/20260526T185422Z_reference_layout_release_ledger.md`
+Created: 2026-05-26T18:54:22Z
+
+## Gate 0 Baseline
+
+- Repo: `/Users/jmajor/projects/daylily/daylily-omics-references`
+- Branch/head: `codex/headnode-readiness-reference-verifier`, `eca57742496496f545a1841e9d287f4a4ca4b851`
+- Dirty state at Gate 0: clean.
+- Latest local tag: `0.3.5`.
+- Sweep command: `rg -n "reference_bucket|control_data_bucket|stage_bucket|--reference-bucket|--control-data-bucket|--stage-bucket|bucket-or-prefix|/fsx/runtime_assets|/fsx/data|/data/staged_sample_data|lsmc-dayoa-omics-analysis-us-west-2" . -S -g '!**/.git/**' -g '!docs/plans/**'`
+- Gate 0 hits: README references `/fsx/data`; source/tests contain internal `clone_reference_bucket` API naming that must be reviewed before renaming because it may mean a real bucket object, not a public `s3://...` field.
+
+## Control Ledger
+
+| ID | Agent | Area | Requirement | Status | Category | Approval Gate | Evidence | Root Cause | Terminal Note |
+|---|---|---|---|---|---|---|---|---|---|
+| DAYREF-BKT-001 | Agent 11 | Layout docs | Replace old `/fsx/data` readiness/layout wording with `/fsx/references` contract. | SUCCESS | feature_implementation | Gate 1 | README readiness wording now says `/fsx/references`. |  | Stale README path removed. |
+| DAYREF-BKT-002 | Agent 11 | Public scrub | Add or update validation that rejects LSMC/RCRF/license/private material in public-safe mirrors. | SUCCESS | contract_test | Gate 1 | Existing `verify --public-safe` and tests reject `.lic`, `license`, `sentieon-genomics`, `lsmc`, `rcrf`, `budget_tags/`, private, and commercial keys; `python -m pytest -q tests/test_manager.py -> 21 passed`. |  | Public-scrub validation already implemented by prior layout ledger and retained. |
+| DAYREF-BKT-003 | Agent 11 | Runtime assets | Represent public-safe runtime helpers under `runtime_assets/...` and references under top-level `genomic_data/...`. | SUCCESS | feature_implementation | Gate 1 | `src/daylily_omics_references/constants.py` expects `runtime_assets/...`, top-level `genomic_data/...`, and `genomic_data/organism_reads_slim/`; shell helper updated to the same layout; tests assert old `data/genomic_data/` is absent; `python -m pytest -q tests/test_manager.py -> 21 passed`. |  | Layout matches the one-DRA references contract and slim-read reference subtree. |
+| DAYREF-BKT-004 | Agent 11 | API naming | Inspect `clone_reference_bucket` naming and only rename if it is a public S3 URI contract conflict. | NO_LONGER_NEEDED | active_product_contract | Gate 1 | `clone_reference_bucket` creates/clones a real S3 bucket and returns a bucket name; it does not accept the removed public `*_bucket=s3://...` config pattern. |  | API name remains because it accurately describes bucket management. |
+| DAYREF-BKT-005 | Agent 13 | Release | PR-merge/tag DayRef before downstream pins when layout tests pass. | BLOCKED | config_or_startup_contract | Release gate | Local latest tag `0.3.5`. | Requires implementation and tests. |  |
+
+## Acceptance Checks
+
+- DayRef active docs/tests reflect `genomic_data/...`, `genomic_data/organism_reads_slim/...`, and `runtime_assets/...`.
+- Public scrub tests fail on LSMC, RCRF, license, Sentieon install tree, and internal budget tag material.
+- DayRef release tag is cut before DayEC/Ursa pins consume it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "daylily-omics-references"
-version = "0.3.5"
+version = "1.0.0"
 description = "Tools for creating and validating Daylily omics analysis reference buckets"
 readme = "README.md"
 authors = [{name = "Daylily Informatics"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "daylily-omics-references"
-version = "0.3.4"
+version = "0.3.5"
 description = "Tools for creating and validating Daylily omics analysis reference buckets"
 readme = "README.md"
 authors = [{name = "Daylily Informatics"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "daylily-omics-references"
-version = "0.3.3"
+version = "0.3.4"
 description = "Tools for creating and validating Daylily omics analysis reference buckets"
 readme = "README.md"
 authors = [{name = "Daylily Informatics"}]

--- a/scripts/daylily-omics-references.sh
+++ b/scripts/daylily-omics-references.sh
@@ -36,6 +36,14 @@ CORE_PREFIXES=(
   "data/tool_specific_resources/"
   "data/budget_tags/"
 )
+DAYEC_REQUIRED_OBJECT_KEYS=(
+  "data/cached_envs/apptainer_1.4.5_amd64.deb"
+  "data/tool_specific_resources/cromwell_87.jar"
+  "data/tool_specific_resources/womtool_87.jar"
+)
+DAYEC_REQUIRED_PREFIXES=(
+  "data/cached_envs/conda/"
+)
 HG38_PREFIXES=(
   "data/genomic_data/organism_references/H_sapiens/hg38/"
   "data/genomic_data/organism_annotations/H_sapiens/hg38/"
@@ -209,6 +217,11 @@ prefix_exists() {
   [[ $(echo "$output" | jq '.Contents | length') -gt 0 ]]
 }
 
+object_exists() {
+  local bucket="$1" key="$2"
+  aws s3api head-object --bucket "$bucket" --key "$key" >/dev/null 2>&1
+}
+
 clone_bucket() {
   local bucket_prefix="$1" region="$2" version="$3" dry_run="$4" include_hg38="$5" include_b37="$6" include_giab="$7" use_accel="$8" log_file="$9"
 
@@ -280,9 +293,27 @@ verify_bucket() {
       missing+=("$p")
     fi
   done
+  for p in "${DAYEC_REQUIRED_PREFIXES[@]}"; do
+    if ! prefix_exists "$bucket" "$p"; then
+      missing+=("$p")
+    fi
+  done
 
   if [[ ${#missing[@]} -gt 0 ]]; then
     log ERROR "Bucket '$bucket' is missing expected prefixes: ${missing[*]}"
+    return 1
+  fi
+
+  local missing_objects=()
+  local key
+  for key in "${DAYEC_REQUIRED_OBJECT_KEYS[@]}"; do
+    if ! object_exists "$bucket" "$key"; then
+      missing_objects+=("$key")
+    fi
+  done
+
+  if [[ ${#missing_objects[@]} -gt 0 ]]; then
+    log ERROR "Bucket '$bucket' is missing DAY-EC required objects: ${missing_objects[*]}"
     return 1
   fi
 

--- a/scripts/daylily-omics-references.sh
+++ b/scripts/daylily-omics-references.sh
@@ -31,29 +31,29 @@ get_source_bucket_for_version() {
 }
 
 CORE_PREFIXES=(
-  "cluster_boot_config/"
-  "data/cached_envs/"
-  "data/tool_specific_resources/"
-  "data/budget_tags/"
+  "runtime_assets/cluster_boot_config/"
+  "runtime_assets/cached_envs/"
+  "runtime_assets/tool_specific_resources/"
+  "runtime_assets/budget_tags/"
 )
 DAYEC_REQUIRED_OBJECT_KEYS=(
-  "data/cached_envs/apptainer_1.4.5_amd64.deb"
-  "data/tool_specific_resources/cromwell_87.jar"
-  "data/tool_specific_resources/womtool_87.jar"
+  "runtime_assets/cached_envs/apptainer_1.4.5_amd64.deb"
+  "runtime_assets/tool_specific_resources/cromwell_87.jar"
+  "runtime_assets/tool_specific_resources/womtool_87.jar"
 )
 DAYEC_REQUIRED_PREFIXES=(
-  "data/cached_envs/conda/"
+  "runtime_assets/cached_envs/conda/"
 )
 HG38_PREFIXES=(
-  "data/genomic_data/organism_references/H_sapiens/hg38/"
-  "data/genomic_data/organism_annotations/H_sapiens/hg38/"
+  "genomic_data/organism_references/H_sapiens/hg38/"
+  "genomic_data/organism_annotations/H_sapiens/hg38/"
 )
 B37_PREFIXES=(
-  "data/genomic_data/organism_references/H_sapiens/b37/"
-  "data/genomic_data/organism_annotations/H_sapiens/b37/"
+  "genomic_data/organism_references/H_sapiens/b37/"
+  "genomic_data/organism_annotations/H_sapiens/b37/"
 )
 GIAB_PREFIXES=(
-  "data/genomic_data/organism_reads/"
+  "genomic_data/organism_reads_slim/"
 )
 
 log() {

--- a/src/boto3/session.py
+++ b/src/boto3/session.py
@@ -39,6 +39,9 @@ class S3Client:
     def get_object(self, **params: Any) -> Dict[str, Any]:
         return self._dispatch("get_object", params)
 
+    def head_object(self, **params: Any) -> Dict[str, Any]:
+        return self._dispatch("head_object", params)
+
     def list_objects_v2(self, **params: Any) -> Dict[str, Any]:
         return self._dispatch("list_objects_v2", params)
 
@@ -115,6 +118,12 @@ class S3Client:
             raise ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "GetObject")
         data = bucket[Key]
         return {"Body": StreamingBody(io.BytesIO(data), len(data))}
+
+    def _handle_head_object(self, Bucket: str, Key: str) -> Dict[str, Any]:
+        bucket = self._buckets.get(Bucket)
+        if not bucket or Key not in bucket:
+            raise ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject")
+        return {}
 
     def _handle_list_objects_v2(
         self, Bucket: str, Prefix: str | None = None, MaxKeys: int = 1

--- a/src/daylily_omics_references/cli.py
+++ b/src/daylily_omics_references/cli.py
@@ -100,6 +100,11 @@ def _parse_args(argv: Iterable[str]) -> argparse.Namespace:
         action="store_true",
         help="Skip checking GIAB reads",
     )
+    verify.add_argument(
+        "--public-safe",
+        action="store_true",
+        help="Reject private, commercial, LSMC/RCRF, license, or internal runtime assets",
+    )
 
     ensure = sub.add_parser(
         "ensure",
@@ -187,6 +192,7 @@ def main(argv: Iterable[str] | None = None) -> int:
                 include_hg38=include_hg38,
                 include_b37=include_b37,
                 include_giab=include_giab,
+                public_safe=args.public_safe,
             )
         elif args.command == "ensure":
             region = args.region or manager.region

--- a/src/daylily_omics_references/constants.py
+++ b/src/daylily_omics_references/constants.py
@@ -19,6 +19,17 @@ CORE_PREFIXES = (
     "data/budget_tags/",
 )
 
+# Exact assets DAY-EC must see under /fsx/data before workflow launch.
+DAYEC_REQUIRED_OBJECT_KEYS = (
+    "data/cached_envs/apptainer_1.4.5_amd64.deb",
+    "data/tool_specific_resources/cromwell_87.jar",
+    "data/tool_specific_resources/womtool_87.jar",
+)
+
+DAYEC_REQUIRED_PREFIXES = (
+    "data/cached_envs/conda/",
+)
+
 # Optional prefixes that may be toggled via CLI flags.
 HG38_PREFIXES = (
     "data/genomic_data/organism_references/H_sapiens/hg38/",

--- a/src/daylily_omics_references/constants.py
+++ b/src/daylily_omics_references/constants.py
@@ -42,7 +42,7 @@ B37_PREFIXES = (
 )
 
 GIAB_PREFIXES = (
-    "genomic_data/organism_reads/",
+    "genomic_data/organism_reads_slim/",
 )
 
 PUBLIC_SAFE_SCAN_PREFIXES = (

--- a/src/daylily_omics_references/constants.py
+++ b/src/daylily_omics_references/constants.py
@@ -13,36 +13,49 @@ SUPPORTED_REFERENCE_VERSIONS = tuple(SOURCE_BUCKET_BY_VERSION.keys())
 
 # Prefixes that are always required in a destination bucket.
 CORE_PREFIXES = (
-    "cluster_boot_config/",
-    "data/cached_envs/",
-    "data/tool_specific_resources/",
-    "data/budget_tags/",
+    "runtime_assets/cluster_boot_config/",
+    "runtime_assets/cached_envs/",
+    "runtime_assets/tool_specific_resources/",
+    "runtime_assets/budget_tags/",
 )
 
-# Exact assets DAY-EC must see under /fsx/data before workflow launch.
+# Exact assets DAY-EC must see under /fsx/references/runtime_assets before workflow launch.
 DAYEC_REQUIRED_OBJECT_KEYS = (
-    "data/cached_envs/apptainer_1.4.5_amd64.deb",
-    "data/tool_specific_resources/cromwell_87.jar",
-    "data/tool_specific_resources/womtool_87.jar",
+    "runtime_assets/cached_envs/apptainer_1.4.5_amd64.deb",
+    "runtime_assets/tool_specific_resources/cromwell_87.jar",
+    "runtime_assets/tool_specific_resources/womtool_87.jar",
 )
 
 DAYEC_REQUIRED_PREFIXES = (
-    "data/cached_envs/conda/",
+    "runtime_assets/cached_envs/conda/",
 )
 
 # Optional prefixes that may be toggled via CLI flags.
 HG38_PREFIXES = (
-    "data/genomic_data/organism_references/H_sapiens/hg38/",
-    "data/genomic_data/organism_annotations/H_sapiens/hg38/",
+    "genomic_data/organism_references/H_sapiens/hg38/",
+    "genomic_data/organism_annotations/H_sapiens/hg38/",
 )
 
 B37_PREFIXES = (
-    "data/genomic_data/organism_references/H_sapiens/b37/",
-    "data/genomic_data/organism_annotations/H_sapiens/b37/",
+    "genomic_data/organism_references/H_sapiens/b37/",
+    "genomic_data/organism_annotations/H_sapiens/b37/",
 )
 
 GIAB_PREFIXES = (
-    "data/genomic_data/organism_reads/",
+    "genomic_data/organism_reads/",
+)
+
+PUBLIC_SAFE_SCAN_PREFIXES = (
+    "runtime_assets/",
+)
+
+PUBLIC_FORBIDDEN_KEY_FRAGMENTS = (
+    ".lic",
+    "license",
+    "sentieon-genomics",
+    "lsmc",
+    "rcrf",
+    "budget_tags/",
 )
 
 VERSION_INFO_KEY = "s3_reference_data_version.info"

--- a/src/daylily_omics_references/manager.py
+++ b/src/daylily_omics_references/manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -24,6 +25,8 @@ from .constants import (
     DEFAULT_REFERENCE_VERSION,
     GIAB_PREFIXES,
     HG38_PREFIXES,
+    PUBLIC_FORBIDDEN_KEY_FRAGMENTS,
+    PUBLIC_SAFE_SCAN_PREFIXES,
     SOURCE_BUCKET_BY_VERSION,
     VERSION_INFO_KEY,
 )
@@ -497,6 +500,7 @@ class ReferenceBucketManager:
         include_hg38: bool = True,
         include_b37: bool = True,
         include_giab: bool = True,
+        public_safe: bool = False,
     ) -> None:
         """Verify that *bucket* contains the expected structure and version."""
 
@@ -535,6 +539,9 @@ class ReferenceBucketManager:
             if not self._object_exists(bucket, key):
                 issues.append(f"missing DAY-EC required object {key}")
 
+        if public_safe:
+            issues.extend(self._public_safe_issues(bucket))
+
         if issues:
             raise BucketVerificationError(bucket, issues)
 
@@ -572,6 +579,36 @@ class ReferenceBucketManager:
         else:
             self._log_boto_response("s3.head_object", response)
             return True
+
+    def _iter_keys_with_prefix(self, bucket: str, prefix: str) -> List[str]:
+        keys: List[str] = []
+        token = None
+        while True:
+            kwargs = {"Bucket": bucket, "Prefix": prefix, "MaxKeys": 1000}
+            if token:
+                kwargs["ContinuationToken"] = token
+            self._log_boto_call("s3.list_objects_v2", **kwargs)
+            response = self.s3_client.list_objects_v2(**kwargs)
+            self._log_boto_response("s3.list_objects_v2", response)
+            keys.extend(str(item.get("Key", "")) for item in response.get("Contents", []))
+            if not response.get("IsTruncated"):
+                return [key for key in keys if key]
+            token = response.get("NextContinuationToken")
+            if not token:
+                raise RuntimeError(
+                    f"S3 listing for {bucket}/{prefix} was truncated without a continuation token"
+                )
+
+    def _public_safe_issues(self, bucket: str) -> List[str]:
+        issues: List[str] = []
+        for prefix in PUBLIC_SAFE_SCAN_PREFIXES:
+            for key in self._iter_keys_with_prefix(bucket, prefix):
+                lowered = key.lower()
+                if any(fragment in lowered for fragment in PUBLIC_FORBIDDEN_KEY_FRAGMENTS):
+                    issues.append(f"public-safe bucket contains forbidden key {key}")
+                if re.search(r"(^|/)(sentieon|license|private|commercial)(/|$)", lowered):
+                    issues.append(f"public-safe bucket contains forbidden private/commercial key {key}")
+        return issues
 
     def _log_bucket_cli_list(self, bucket: str) -> None:
         """Run and log a verbose aws s3 ls against ``bucket``."""

--- a/src/daylily_omics_references/manager.py
+++ b/src/daylily_omics_references/manager.py
@@ -19,6 +19,8 @@ import botocore.exceptions as botocore_exceptions
 from .constants import (
     B37_PREFIXES,
     CORE_PREFIXES,
+    DAYEC_REQUIRED_OBJECT_KEYS,
+    DAYEC_REQUIRED_PREFIXES,
     DEFAULT_REFERENCE_VERSION,
     GIAB_PREFIXES,
     HG38_PREFIXES,
@@ -525,6 +527,14 @@ class ReferenceBucketManager:
             if not self._prefix_exists(bucket, prefix):
                 issues.append(f"missing objects under {prefix}")
 
+        for prefix in DAYEC_REQUIRED_PREFIXES:
+            if not self._prefix_exists(bucket, prefix):
+                issues.append(f"missing DAY-EC required objects under {prefix}")
+
+        for key in DAYEC_REQUIRED_OBJECT_KEYS:
+            if not self._object_exists(bucket, key):
+                issues.append(f"missing DAY-EC required object {key}")
+
         if issues:
             raise BucketVerificationError(bucket, issues)
 
@@ -544,6 +554,24 @@ class ReferenceBucketManager:
         )
         self._log_boto_response("s3.list_objects_v2", response)
         return "Contents" in response and bool(response["Contents"])
+
+    def _object_exists(self, bucket: str, key: str) -> bool:
+        self._log_boto_call("s3.head_object", Bucket=bucket, Key=key)
+        try:
+            response = self.s3_client.head_object(Bucket=bucket, Key=key)
+        except ClientError as error:
+            if self._maybe_redirect_s3_client(bucket, error):
+                try:
+                    redirected_response = self.s3_client.head_object(Bucket=bucket, Key=key)
+                except ClientError:
+                    return False
+                else:
+                    self._log_boto_response("s3.head_object", redirected_response)
+                    return True
+            return False
+        else:
+            self._log_boto_response("s3.head_object", response)
+            return True
 
     def _log_bucket_cli_list(self, bucket: str) -> None:
         """Run and log a verbose aws s3 ls against ``bucket``."""

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -15,6 +15,8 @@ from daylily_omics_references import BucketVerificationError, ReferenceBucketMan
 from daylily_omics_references.constants import (
     B37_PREFIXES,
     CORE_PREFIXES,
+    DAYEC_REQUIRED_OBJECT_KEYS,
+    DAYEC_REQUIRED_PREFIXES,
     DEFAULT_REFERENCE_VERSION,
     GIAB_PREFIXES,
     HG38_PREFIXES,
@@ -141,6 +143,18 @@ def test_verify_bucket_success(include_hg38: bool, include_b37: bool, include_gi
                 {"Contents": [{"Key": f"{prefix}dummy"}]},
                 {"Bucket": "target", "Prefix": prefix, "MaxKeys": 1},
             )
+        for prefix in DAYEC_REQUIRED_PREFIXES:
+            stubber.add_response(
+                "list_objects_v2",
+                {"Contents": [{"Key": f"{prefix}dummy"}]},
+                {"Bucket": "target", "Prefix": prefix, "MaxKeys": 1},
+            )
+        for key in DAYEC_REQUIRED_OBJECT_KEYS:
+            stubber.add_response(
+                "head_object",
+                {},
+                {"Bucket": "target", "Key": key},
+            )
 
         manager.verify_bucket(
             "target",
@@ -155,7 +169,8 @@ def test_verify_bucket_excludes_data_lib_prefix():
 
     with mock.patch.object(manager, "bucket_exists", return_value=True), \
         mock.patch.object(manager, "read_bucket_version", return_value=DEFAULT_REFERENCE_VERSION), \
-        mock.patch.object(manager, "_prefix_exists", return_value=True) as mock_prefix_exists:
+        mock.patch.object(manager, "_prefix_exists", return_value=True) as mock_prefix_exists, \
+        mock.patch.object(manager, "_object_exists", return_value=True) as mock_object_exists:
         manager.verify_bucket(
             "target",
             include_hg38=False,
@@ -164,7 +179,9 @@ def test_verify_bucket_excludes_data_lib_prefix():
         )
 
     checked_prefixes = [call.args[1] for call in mock_prefix_exists.call_args_list]
-    assert checked_prefixes == list(CORE_PREFIXES)
+    assert checked_prefixes == list(CORE_PREFIXES) + list(DAYEC_REQUIRED_PREFIXES)
+    checked_objects = [call.args[1] for call in mock_object_exists.call_args_list]
+    assert checked_objects == list(DAYEC_REQUIRED_OBJECT_KEYS)
     assert "data/lib/" not in checked_prefixes
 
 
@@ -203,11 +220,74 @@ def test_verify_bucket_missing_prefix():
                     {"Contents": [{"Key": f"{prefix}dummy"}]},
                     {"Bucket": "target", "Prefix": prefix, "MaxKeys": 1},
                 )
+        for prefix in DAYEC_REQUIRED_PREFIXES:
+            stubber.add_response(
+                "list_objects_v2",
+                {"Contents": [{"Key": f"{prefix}dummy"}]},
+                {"Bucket": "target", "Prefix": prefix, "MaxKeys": 1},
+            )
+        for key in DAYEC_REQUIRED_OBJECT_KEYS:
+            stubber.add_response(
+                "head_object",
+                {},
+                {"Bucket": "target", "Key": key},
+            )
 
         with pytest.raises(BucketVerificationError) as exc:
             manager.verify_bucket("target")
 
     assert "missing objects" in str(exc.value)
+
+
+def test_verify_bucket_missing_dayec_required_object():
+    session = boto3.session.Session(region_name="us-west-2")
+    client = session.client("s3")
+    manager = ReferenceBucketManager(session=session, s3_client=client)
+    stubber = Stubber(client)
+
+    prefixes = list(CORE_PREFIXES) + list(HG38_PREFIXES) + list(B37_PREFIXES) + list(GIAB_PREFIXES)
+    missing_key = DAYEC_REQUIRED_OBJECT_KEYS[0]
+
+    with stubber:
+        stubber.add_response("head_bucket", {}, {"Bucket": "target"})
+        stubber.add_response(
+            "get_object",
+            {"Body": _version_body(DEFAULT_REFERENCE_VERSION)},
+            {"Bucket": "target", "Key": VERSION_INFO_KEY},
+        )
+        for prefix in prefixes:
+            stubber.add_response(
+                "list_objects_v2",
+                {"Contents": [{"Key": f"{prefix}dummy"}]},
+                {"Bucket": "target", "Prefix": prefix, "MaxKeys": 1},
+            )
+        for prefix in DAYEC_REQUIRED_PREFIXES:
+            stubber.add_response(
+                "list_objects_v2",
+                {"Contents": [{"Key": f"{prefix}dummy"}]},
+                {"Bucket": "target", "Prefix": prefix, "MaxKeys": 1},
+            )
+        for key in DAYEC_REQUIRED_OBJECT_KEYS:
+            if key == missing_key:
+                stubber.add_response(
+                    "head_object",
+                    ClientError(
+                        {"Error": {"Code": "404", "Message": "Not Found"}},
+                        "HeadObject",
+                    ),
+                    {"Bucket": "target", "Key": key},
+                )
+            else:
+                stubber.add_response(
+                    "head_object",
+                    {},
+                    {"Bucket": "target", "Key": key},
+                )
+
+        with pytest.raises(BucketVerificationError) as exc:
+            manager.verify_bucket("target")
+
+    assert f"missing DAY-EC required object {missing_key}" in str(exc.value)
 
 
 def test_ensure_bucket_missing_without_create():
@@ -238,7 +318,8 @@ def test_create_bucket_applies_policy():
 
     manager = ReferenceBucketManager(s3_client=s3, sts_client=sts)
 
-    manager.create_bucket("target", "us-west-2", dry_run=False)
+    with mock.patch.object(manager, "_log_bucket_cli_list") as mock_log_bucket_cli_list:
+        manager.create_bucket("target", "us-west-2", dry_run=False)
 
     s3.create_bucket.assert_called_once_with(
         Bucket="target",
@@ -255,6 +336,7 @@ def test_create_bucket_applies_policy():
     assert {"AWS": "arn:aws:iam::123456789012:root"} in [
         statement.get("Principal") for statement in policy["Statement"]
     ]
+    mock_log_bucket_cli_list.assert_called_once_with("target")
 
 
 def test_create_bucket_dry_run_skips_api_calls():
@@ -313,6 +395,7 @@ def test_verify_bucket_handles_redirect(monkeypatch):
         return {"Contents": [{"Key": f"{kwargs['Prefix']}dummy"}]}
 
     second.list_objects_v2.side_effect = _list_objects_side_effect
+    second.head_object.return_value = {}
 
     manager.verify_bucket("target")
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -187,6 +187,8 @@ def test_verify_bucket_excludes_data_lib_prefix():
 
 def test_core_prefixes_do_not_include_data_lib():
     assert "data/lib/" not in CORE_PREFIXES
+    assert "data/genomic_data/" not in CORE_PREFIXES
+    assert all(prefix.startswith("runtime_assets/") for prefix in CORE_PREFIXES)
 
 
 def test_verify_bucket_missing_prefix():
@@ -288,6 +290,73 @@ def test_verify_bucket_missing_dayec_required_object():
             manager.verify_bucket("target")
 
     assert f"missing DAY-EC required object {missing_key}" in str(exc.value)
+
+
+def test_verify_bucket_private_lsmc_style_allows_private_runtime_assets():
+    manager = ReferenceBucketManager()
+
+    with mock.patch.object(manager, "bucket_exists", return_value=True), \
+        mock.patch.object(manager, "read_bucket_version", return_value=DEFAULT_REFERENCE_VERSION), \
+        mock.patch.object(manager, "_prefix_exists", return_value=True), \
+        mock.patch.object(manager, "_object_exists", return_value=True), \
+        mock.patch.object(
+            manager,
+            "_iter_keys_with_prefix",
+            return_value=[
+                "runtime_assets/cached_envs/x.lic",
+                "runtime_assets/cached_envs/sentieon-genomics-202503.02/bin/sentieon",
+                "runtime_assets/budget_tags/pcluster-project-budget-tags.tsv",
+            ],
+        ) as mock_iter:
+        manager.verify_bucket("target", include_b37=False, public_safe=False)
+
+    mock_iter.assert_not_called()
+
+
+def test_verify_bucket_public_safe_rejects_private_runtime_assets():
+    manager = ReferenceBucketManager()
+
+    with mock.patch.object(manager, "bucket_exists", return_value=True), \
+        mock.patch.object(manager, "read_bucket_version", return_value=DEFAULT_REFERENCE_VERSION), \
+        mock.patch.object(manager, "_prefix_exists", return_value=True), \
+        mock.patch.object(manager, "_object_exists", return_value=True), \
+        mock.patch.object(
+            manager,
+            "_iter_keys_with_prefix",
+            return_value=[
+                "runtime_assets/cached_envs/x.lic",
+                "runtime_assets/cached_envs/sentieon-genomics-202503.02/bin/sentieon",
+                "runtime_assets/budget_tags/pcluster-project-budget-tags.tsv",
+                "runtime_assets/tool_specific_resources/lsmc-helper.txt",
+            ],
+        ):
+        with pytest.raises(BucketVerificationError) as exc:
+            manager.verify_bucket("target", include_b37=False, public_safe=True)
+
+    message = str(exc.value)
+    assert "x.lic" in message
+    assert "sentieon-genomics" in message
+    assert "budget_tags" in message
+    assert "lsmc-helper" in message
+
+
+def test_verify_bucket_public_safe_accepts_public_runtime_helpers():
+    manager = ReferenceBucketManager()
+
+    with mock.patch.object(manager, "bucket_exists", return_value=True), \
+        mock.patch.object(manager, "read_bucket_version", return_value=DEFAULT_REFERENCE_VERSION), \
+        mock.patch.object(manager, "_prefix_exists", return_value=True), \
+        mock.patch.object(manager, "_object_exists", return_value=True), \
+        mock.patch.object(
+            manager,
+            "_iter_keys_with_prefix",
+            return_value=[
+                "runtime_assets/cluster_boot_config/post_install_ubuntu_combined.sh",
+                "runtime_assets/tool_specific_resources/cromwell_87.jar",
+                "runtime_assets/tool_specific_resources/womtool_87.jar",
+            ],
+        ):
+        manager.verify_bucket("target", include_b37=False, public_safe=True)
 
 
 def test_ensure_bucket_missing_without_create():


### PR DESCRIPTION
## Summary
- move the expected reference layout to top-level genomic_data plus runtime_assets
- switch GIAB validation reads to genomic_data/organism_reads_slim
- add the durable release ledger for the bucket-contract cutover
- bump package version to 1.0.0

## Tests
- python -m pytest -q tests/test_manager.py